### PR TITLE
feat: improve voicevox-go configuration and ansible setup

### DIFF
--- a/ansible/roles/mac/files/.aws/amazonq/mcp.json
+++ b/ansible/roles/mac/files/.aws/amazonq/mcp.json
@@ -1,12 +1,13 @@
 {
   "mcpServers": {
     "voicevox-go": {
-      "command": "mcp-voicevox",
+      "command": "mcp-voicevox-go",
       "args": [
         "stdio"
       ],
       "env": {
-        "MCP_VOICEVOX_ENABLE_PLAYBACK": "true"
+        "MCP_VOICEVOX_ENABLE_PLAYBACK": "true",
+        "MCP_VOICEVOX_DEFAULT_SPEED_SCALE": "1.5"
       },
       "autoApprove": [
         "get_speakers",

--- a/bin/mac/setup.sh
+++ b/bin/mac/setup.sh
@@ -29,4 +29,4 @@ if [ ! -d "$ansible_path/inventories/$inventory_file_path" ]; then
   exit 1
 fi
 
-ansible-playbook -c local -i $ansible_path/inventories/$inventory_file_path/hosts.yaml $ansible_path/setup_mac.yaml 
+ansible-playbook -c local -i $ansible_path/inventories/$inventory_file_path/hosts.yaml $ansible_path/setup_mac.yaml --ask-become-pass


### PR DESCRIPTION
- Update mcp-voicevox command to mcp-voicevox-go
- Add default speed scale configuration for voicevox
- Add --ask-become-pass flag to ansible-playbook execution